### PR TITLE
Update 2. Additional Questions.md

### DIFF
--- a/11. Additional/2. Additional Questions.md
+++ b/11. Additional/2. Additional Questions.md
@@ -197,7 +197,7 @@
         <fieldsets>
             <sales_convert_quote_address>
                 <base_discount>
-                    <to_order>\*</to_order>
+                    <to_order>*</to_order>
                 </base_discount>
             </sales_convert_quote_address>
         </fieldsets>
@@ -209,7 +209,7 @@
 4. Transfer data of field base_discount field from order to address when creating an order
 5. Transfer data of field base_discount from quote to order when a customer orders.
 
-**Answer:** 5
+**Answer:** 2
 
 ## Which tags below are NOT used in declaring XML layout? (2 correct answers)
 


### PR DESCRIPTION
Sales_convert_quote_address fieldset are using for transfer data from quote address.

Method reference: 
`Mage_Sales_Model_Convert_Quote::addressToOrder(Mage_Sales_Model_Quote_Address $address, $order=null)`

Usage: 
`Mage::helper('core')->copyFieldset('sales_convert_quote_address', 'to_order', $address, $order);`